### PR TITLE
offchain-metadata-tools v0.1.0.0 release

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,8 +53,8 @@ jobs:
 
           popd
           echo "Obtaining the latest metadata GitHub PR validation tool:"
-          echo "curl -sLO https://hydra.iohk.io/job/Cardano/metadata-server/native.metadataValidatorGitHubTarball.x86_64-linux/latest-finished/download/1/metadata-validator-github.tar.gz"
-          curl -sLO https://hydra.iohk.io/job/Cardano/metadata-server/native.metadataValidatorGitHubTarball.x86_64-linux/latest-finished/download/1/metadata-validator-github.tar.gz
+          echo "curl -sLO https://hydra.iohk.io/job/Cardano/offchain-metadata-tools/musl64.metadata-validator-github-tarball.x86_64-linux/latest/download/1/metadata-validator-github.tar.gz"
+          curl -sLO https://hydra.iohk.io/job/Cardano/offchain-metadata-tools/musl64.metadata-validator-github-tarball.x86_64-linux/latest/download/1/metadata-validator-github.tar.gz
           echo
 
           echo "Extracting the latest metadata GitHub PR validation tool:"
@@ -68,17 +68,17 @@ jobs:
           echo
 
           echo "Obtaining the latest metadata validation tool:"
-          echo "curl -sLO https://hydra.iohk.io/job/Cardano/cardano-metadata-submitter/native.metadataSubmitterTarball.x86_64-linux/latest-finished/download/1/cardano-metadata-submitter.tar.gz"
-          curl -sLO https://hydra.iohk.io/job/Cardano/cardano-metadata-submitter/native.metadataSubmitterTarball.x86_64-linux/latest-finished/download/1/cardano-metadata-submitter.tar.gz
+          echo "curl -sLO https://hydra.iohk.io/job/Cardano/offchain-metadata-tools/musl64.token-metadata-creator-tarball.x86_64-linux/latest/download/1/token-metadata-creator.tar.gz"
+          curl -sLO https://hydra.iohk.io/job/Cardano/offchain-metadata-tools/musl64.token-metadata-creator-tarball.x86_64-linux/latest/download/1/token-metadata-creator.tar.gz
           echo
 
           echo "Extracting the latest metadata validation tool:"
-          tar -zxvf cardano-metadata-submitter.tar.gz
+          tar -zxvf token-metadata-creator.tar.gz
           echo
 
           echo "Running the metadata validation tool on this PR:"
           echo
-          VALIDATOR="./cardano-metadata-submitter validate"
+          VALIDATOR="./token-metadata-creator validate"
           echo "${DIFF}" | grep "^M" | awk '{print $2}' | xargs --no-run-if-empty -- bash -c 'echo "$1 master/$2 pull-request/$2" && $1 master/$2 pull-request/$2' -- "$VALIDATOR"
           echo "${DIFF}" | grep "^A" | awk '{print $2}' | xargs --no-run-if-empty -- bash -c 'echo "$1 pull-request/$2" && $1 pull-request/$2' -- "$VALIDATOR"
           echo

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -4,7 +4,7 @@ with {
     inherit (import sources.nixpkgs-unstable {}) niv;
     inherit (import sources.cardano-node { gitrev = sources.cardano-node.rev; }) cardano-cli;
     inherit (import sources.cardano-node { gitrev = sources.cardano-node.rev; }) bech32;
-    inherit (import sources.cardano-metadata-submitter {}) cardano-metadata-submitter;
+    inherit (import sources.offchain-metadata-tools {}) token-metadata-creator;
   };
 };
 import sources.nixpkgs {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -1,16 +1,4 @@
 {
-    "cardano-metadata-submitter": {
-        "branch": "master",
-        "description": "A library and CLI for manipulating data for the Metadata Server CIP",
-        "homepage": null,
-        "owner": "input-output-hk",
-        "repo": "cardano-metadata-submitter",
-        "rev": "fcf1010538fbc9bbc00ef1ed8fa37fa06287af45",
-        "sha256": "13mrzr5x2nqc85awljv75xlpfwbdmvcclgyr2ql1cla2gzy6b3a8",
-        "type": "tarball",
-        "url": "https://github.com/input-output-hk/cardano-metadata-submitter/archive/fcf1010538fbc9bbc00ef1ed8fa37fa06287af45.tar.gz",
-        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
-    },
     "cardano-node": {
         "branch": "refs/tags/1.25.1",
         "description": "The core component that is used to participate in a Cardano decentralised blockchain.",
@@ -57,6 +45,18 @@
         "sha256": "0idvgvpgnzvk03yvd77lrca9qib936fq2x690jvk5gk3blsckz3r",
         "type": "tarball",
         "url": "https://github.com/NixOS/nixpkgs/archive/410bbd828cdc6156aecd5bc91772ad3a6b1099c7.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
+    "offchain-metadata-tools": {
+        "branch": "refs/tags/v0.1.0.0",
+        "description": "Tools for creating, submitting, and managing off-chain metadata such as multi-asset token metadata",
+        "homepage": "",
+        "owner": "input-output-hk",
+        "repo": "offchain-metadata-tools",
+        "rev": "040cfa44f58eea6ca8c8bb4576ba352d17689be5",
+        "sha256": "0ryvz08k1fp1s8bli87zdjzq0nn416s5c47h70v6f8qd9kvr40qk",
+        "type": "tarball",
+        "url": "https://github.com/input-output-hk/offchain-metadata-tools/archive/040cfa44f58eea6ca8c8bb4576ba352d17689be5.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/shell.nix
+++ b/shell.nix
@@ -2,7 +2,7 @@ with { pkgs = import ./nix { }; };
 pkgs.mkShell {
   buildInputs = with pkgs; [
     bech32
-    cardano-metadata-submitter
+    token-metadata-creator
     cardano-cli
     niv
     jq


### PR DESCRIPTION
- The "metadata-server" project has been renamed to
  "offchain-metadata-tools". Update this project accordingly.