### PR TITLE
Allow large batch submissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,15 +35,14 @@ jobs:
 
           echo "Obtaining PR file change diff:"
           echo
-          DIFF="$(git --no-pager diff --name-status origin/"${BASE}" "${GITHUB_SHA}")"
-          export DIFF
-          echo "${DIFF}"
+          git --no-pager diff --name-status origin/"${BASE}" "${GITHUB_SHA}" > "${GITHUB_SHA}.diff"
+          cat "${GITHUB_SHA}.diff"
           echo
 
           rm -f fail-location fail-filename || :
           echo "Validating all changed PR files are in the ${LOCATION} directory:"
           echo
-          echo "${DIFF}" | awk '{print $2}' | sort \
+          awk '{print $2}' "${GITHUB_SHA}.diff" | sort \
             | xargs -I{} bash -c '[[ {} =~ ^${LOCATION}/.*$ ]] && echo "pass: {}" || { echo "FAIL: {}"; touch fail-location; }'
           echo
 


### PR DESCRIPTION
## Description

- As reported in https://github.com/cardano-foundation/cardano-token-registry/issues/76, when the DIFF is large, passing the DIFF via stdin hits the Linux argument length limit. Instead, write out DIFF to file, this allows us to have very large DIFFs.
- Fixes #76.
- Committed to testnet here: https://github.com/input-output-hk/metadata-registry-testnet/commit/5704b610cf6651986cb59949c840cf9c43d49b2d, and demonstrated with a large diff here: https://github.com/input-output-hk/metadata-registry-testnet/pull/107

## Type of change

- [ ] Metadata related change
- [x] Other