### PR TITLE
DIFF variable no longer exists, look at file diff instead

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -78,6 +78,6 @@ jobs:
           echo "Running the metadata validation tool on this PR:"
           echo
           VALIDATOR="./token-metadata-creator validate"
-          echo "${DIFF}" | grep "^M" | awk '{print $2}' | xargs --no-run-if-empty -- bash -c 'echo "$1 master/$2 pull-request/$2" && $1 master/$2 pull-request/$2' -- "$VALIDATOR"
-          echo "${DIFF}" | grep "^A" | awk '{print $2}' | xargs --no-run-if-empty -- bash -c 'echo "$1 pull-request/$2" && $1 pull-request/$2' -- "$VALIDATOR"
+          awk '/^M/ {print $2}' "pull-request/${GITHUB_SHA}.diff" | xargs --no-run-if-empty -- bash -c 'echo "$1 master/$2 pull-request/$2" && $1 master/$2 pull-request/$2' -- "$VALIDATOR"
+          awk '/^A/ {print $2}' "pull-request/${GITHUB_SHA}.diff" | xargs --no-run-if-empty -- bash -c 'echo "$1 pull-request/$2" && $1 pull-request/$2' -- "$VALIDATOR"
           echo


### PR DESCRIPTION
# Pull Request

## Description

Issue #76 pointed out that our CI failed on submission of large batch submissions. I made a change to fix this, but forgot to update the whole script - sorry!

I deployed this fix to our testnet repo and you can see that it:
  - Accepts good entries: https://github.com/input-output-hk/metadata-registry-testnet/pull/119
  - Actually rejects bad entries: https://github.com/input-output-hk/metadata-registry-testnet/pull/118
  
This means that the CI script hasn't been validating our PRs properly :( This script was supposed to just be some glue, but it's actually quite important, we'll need to be more careful to test it in future.

## Type of change

- [ ] Metadata related change
- [x] Other

## Checklist:

Not applicable
