### PR TITLE
Bumps nix shell cardano-node, offchain-metadata-tools

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -1,14 +1,14 @@
 {
     "cardano-node": {
-        "branch": "refs/tags/1.25.1",
+        "branch": "refs/tags/1.27.0",
         "description": "The core component that is used to participate in a Cardano decentralised blockchain.",
         "homepage": "https://cardano.org",
         "owner": "input-output-hk",
         "repo": "cardano-node",
-        "rev": "9a7331cce5e8bc0ea9c6bfa1c28773f4c5a7000f",
-        "sha256": "1scffi7igv4kj93bpjf8yibcaq0sskfikmm00f7r6q031l53y50c",
+        "rev": "8fe46140a52810b6ca456be01d652ca08fe730bf",
+        "sha256": "1c9zc899wlgicrs49i33l0bwb554acsavzh1vcyhnxmpm0dmy8vj",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/cardano-node/archive/9a7331cce5e8bc0ea9c6bfa1c28773f4c5a7000f.tar.gz",
+        "url": "https://github.com/input-output-hk/cardano-node/archive/8fe46140a52810b6ca456be01d652ca08fe730bf.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "niv": {
@@ -48,15 +48,15 @@
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "offchain-metadata-tools": {
-        "branch": "refs/tags/v0.1.0.0",
+        "branch": "refs/tags/v0.2.0.0",
         "description": "Tools for creating, submitting, and managing off-chain metadata such as multi-asset token metadata",
         "homepage": "",
         "owner": "input-output-hk",
         "repo": "offchain-metadata-tools",
-        "rev": "040cfa44f58eea6ca8c8bb4576ba352d17689be5",
-        "sha256": "0ryvz08k1fp1s8bli87zdjzq0nn416s5c47h70v6f8qd9kvr40qk",
+        "rev": "dd052829f0f070f91edd67cffe073db1622ea55d",
+        "sha256": "0s3bmgjcgn4lx8mx4iwb3i88nvj03cmyfl1ik85xd7y9rcl1sf0q",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/offchain-metadata-tools/archive/040cfa44f58eea6ca8c8bb4576ba352d17689be5.tar.gz",
+        "url": "https://github.com/input-output-hk/offchain-metadata-tools/archive/dd052829f0f070f91edd67cffe073db1622ea55d.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
….2.0.0

# Pull Request Template

## Description

Bumps nix shell niv pins:
* cardano-node -> 1.27.0
* offchain-metadata-tools -> v0.2.0.0

## Type of change

- [ ] Metadata related change
- [X] Other

## Checklist:

- [ ] For metadata related changes, this PR code passes the Github Actions metadata validation


## Metadata PRs

Please note it may take up to 4 hours for merged changes to take effect on the metadata server.
