### PR TITLE
updated decimal places to 0

### DIFF
--- a/mappings/b0446f1c9105f0cc5bb6bd092f5c3e523e13f8a999b31c870298fa4051554944.json
+++ b/mappings/b0446f1c9105f0cc5bb6bd092f5c3e523e13f8a999b31c870298fa4051554944.json
@@ -32,7 +32,7 @@
     },
     "decimals": {
         "sequenceNumber": 0,
-        "value": 4,
+        "value": 0,
         "signatures": [
             {
                 "signature": "17e271d173aaaa8eb4bf2fafb689d70d95cecb6726e9baa86481268c327787cbca7238a1697688d548c42a4cd0008ee3acbda9072c7a950d96ab963d5b6e450e",


### PR DESCRIPTION
# Pull Request Template

## Description

Please include a short summary of the changes in this PR.
Decimal places show up unexpectedly on pool.pm and Daedalus Wallet. We expected this to be like tokens decimal places on other networks, stating that our decimal places are 4 from ada but that's not true.

## Type of change

- [ ] Metadata related change
- [ ] Other

## Checklist:

- [ ] For metadata related changes, this PR code passes the Github Actions metadata validation


## Metadata PRs

Please note it may take up to 4 hours for merged changes to take effect on the metadata server.
