### PR TITLE
Use HEAD instead of GITHUB_SHA to diff master and PR

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,15 +34,16 @@ jobs:
           echo
 
           echo "Obtaining PR file change diff:"
+          echo "BASE: ${BASE}"
           echo
-          git --no-pager diff --name-status origin/"${BASE}" "${GITHUB_SHA}" > "${GITHUB_SHA}.diff"
-          cat "${GITHUB_SHA}.diff"
+          git --no-pager diff --name-status origin/"${BASE}" HEAD > "HEAD.diff"
+          cat "HEAD.diff"
           echo
 
           rm -f fail-location fail-filename || :
           echo "Validating all changed PR files are in the ${LOCATION} directory:"
           echo
-          awk '{print $2}' "${GITHUB_SHA}.diff" | sort \
+          awk '{print $2}' "HEAD.diff" | sort \
             | xargs -I{} bash -c '[[ {} =~ ^${LOCATION}/.*$ ]] && echo "pass: {}" || { echo "FAIL: {}"; touch fail-location; }'
           echo
 
@@ -78,6 +79,6 @@ jobs:
           echo "Running the metadata validation tool on this PR:"
           echo
           VALIDATOR="./token-metadata-creator validate"
-          awk '/^M/ {print $2}' "pull-request/${GITHUB_SHA}.diff" | xargs --no-run-if-empty -- bash -c 'echo "$1 master/$2 pull-request/$2" && $1 master/$2 pull-request/$2' -- "$VALIDATOR"
-          awk '/^A/ {print $2}' "pull-request/${GITHUB_SHA}.diff" | xargs --no-run-if-empty -- bash -c 'echo "$1 pull-request/$2" && $1 pull-request/$2' -- "$VALIDATOR"
+          awk '/^M/ {print $2}' "pull-request/HEAD.diff" | xargs --no-run-if-empty -- bash -c 'echo "$1 master/$2 pull-request/$2" && $1 master/$2 pull-request/$2' -- "$VALIDATOR"
+          awk '/^A/ {print $2}' "pull-request/HEAD.diff" | xargs --no-run-if-empty -- bash -c 'echo "$1 pull-request/$2" && $1 pull-request/$2' -- "$VALIDATOR"
           echo


### PR DESCRIPTION
## Description

- Using "${GITHUB_SHA}" to point to the pull request commit does not work when
  the pull request comes from a fork. The incorrect SHA leads to the diff being
  incorrect, which leads to validation errors. 
- This PR uses the HEAD symbolic commit to point to the correct state.
- Fix tested in https://github.com/cardano-foundation/cardano-token-registry/pull/1255.
- Fixes https://github.com/cardano-foundation/cardano-token-registry/issues/1121

## Type of change

- [ ] Metadata related change
- [x] Other