### PR TITLE
Updated decimals to 6

### DIFF
--- a/mappings/ea153b5d4864af15a1079a94a0e2486d6376fa28aafad272d15b243a0014df10536861726473.json
+++ b/mappings/ea153b5d4864af15a1079a94a0e2486d6376fa28aafad272d15b243a0014df10536861726473.json
@@ -28,6 +28,6 @@
   "decimals": {
       "signatures": [],
       "sequenceNumber": 0,
-      "value": 0
+      "value": 6
   }
 }


### PR DESCRIPTION
# Pull Request Template

## Description

Token supply is showing 12 decimals on minswap.org. Updated metadata to 6 decimals.

## Type of change

- [X] Metadata related change
- [ ] Other

## Checklist:

- [X] For metadata related changes, this PR code passes the GitHub Actions metadata validation


## Metadata PRs

Please note it may take up to 4 hours for merged changes to take effect on the metadata server.
