### PR TITLE
Modify roaring hosky token decimal places

### DIFF
--- a/mappings/38a678f33270d4740c53bdda15a6672ff491c22f9ab0c6798b4327c8524f4152.json
+++ b/mappings/38a678f33270d4740c53bdda15a6672ff491c22f9ab0c6798b4327c8524f4152.json
@@ -22,7 +22,7 @@
     },
     "decimals": {
         "sequenceNumber": 0,
-        "value": 6,
+        "value": 0,
         "signatures": [
             {
                 "signature": "07f9ad4c2c36dd6b109f5d62dded9091d9cee4b639b3f8758cddd226a0ac5099e224a9beef7f14a1754629cb851fe5e204b09e8e10c7f80fefb1cb712b2a0b06",


### PR DESCRIPTION
# Pull Request Template

## Description

Incorrect decimal places on roaring hosky currency. Changed from 6 to 0.

## Type of change

- [X ] Metadata related change
- [ ] Other

## Checklist:

- [X ] For metadata related changes, this PR code passes the GitHub Actions metadata validation


## Metadata PRs

Please note it may take up to 4 hours for merged changes to take effect on the metadata server.
