### PR TITLE
fix: vulnerability fix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,6 +3,11 @@ on:
   # Trigger on open, synchronize or reopen PR activity against the default base branch
   pull_request_target:
     branches: [ "master" ]
+
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   approve: # Pre-approval step
     runs-on: ubuntu-latest
@@ -65,12 +70,35 @@ jobs:
           rm -f fail-location fail-filename fail-subject-is-hex fail-subject-length || :
           echo "Validating all changed PR files are in the ${LOCATION} directory and are hex and are valid length filenames:"
           echo
-          awk '{print $2}' "HEAD.diff" | sort \
-            | xargs -I{} bash -c '[[ {} =~ ^${LOCATION}/.*$ ]] && echo "pass location: {}" || { echo "FAIL location: {}"; touch fail-location; }'
-          awk '{print $2}' "HEAD.diff" | sort \
-            | xargs -I{} bash -c '[[ {} =~ ^${LOCATION}/[0-9a-f]*\.json$ ]] && echo "pass is hex: {}" || { echo "FAIL is hex: {}"; touch fail-subject-is-hex; }'
-          awk '{print $2}' "HEAD.diff" | sort \
-            | xargs -I{} bash -c 'FNAME={}; FLENGTH=${#FNAME}; if (( $FLENGTH % 2 )); then echo "FAIL length: $FNAME"; touch fail-subject-length; else echo "pass length: $FNAME"; fi'
+          awk '{print $2}' "HEAD.diff" | sort | while read -r fname; do
+            [ -z "$fname" ] && continue  # skip empty lines
+
+            # Check if filename starts with the correct location
+            if [[ "$fname" =~ ^${LOCATION}/.*$ ]]; then
+              echo "pass location: $fname"
+            else
+              echo "FAIL location: $fname"
+              touch fail-location
+            fi
+
+            # Check if filename is a hex string ending in .json
+            if [[ "$fname" =~ ^${LOCATION}/[0-9a-f]+\.json$ ]]; then
+              echo "pass is hex: $fname"
+            else
+              echo "FAIL is hex: $fname"
+              touch fail-subject-is-hex
+            fi
+
+            # Extract just the filename for length check
+            justname=$(basename "$fname" .json)
+            flength=${#justname}
+            if (( flength % 2 == 0 )); then
+              echo "pass length: $fname"
+            else
+              echo "FAIL length: $fname"
+              touch fail-subject-length
+            fi
+          done
           echo
 
           [ -f "fail-location" ] && echo "ABORTING: File change location validation failed"


### PR DESCRIPTION
…workflow

fix: added read only permission for the CI workflow.

# Pull Request Template

## Description
Vulnerable Workflow
The following step in your workflow processes changed files:

gh api \
  -H "Accept: application/vnd.github+json" \
  /repos/cardano-foundation/cardano-token-registry/pulls/${PR}/files \
  | jq --raw-output -c '.[] | [.status, .filename] | @csv' | sed $'s/,/\t/g; s/\"//g; s/added/A/g; s/modified/M/g; s/removed/D/g; s/renamed/R/g; s/copied/C/g; s/changed/T/g; s/unchanged/U/g' \
  > "HEAD.diff"
Later, filenames from HEAD.diff are passed into xargs and interpolated directly into shell commands:

awk '{print $2}' "HEAD.diff" | sort \
  | xargs -I{} bash -c '[[ {} =~ ^${LOCATION}/.*$ ]] && echo "pass location: {}" || { echo "FAIL location: {}"; touch fail-location; }'

awk '{print $2}' "HEAD.diff" | sort \
  | xargs -I{} bash -c '[[ {} =~ ^${LOCATION}/[0-9a-f]*\.json$ ]] && echo "pass is hex: {}" || { echo "FAIL is hex: {}"; touch fail-subject-is-hex; }'

awk '{print $2}' "HEAD.diff" | sort \
  | xargs -I{} bash -c 'FNAME={}; FLENGTH=${#FNAME}; if (( $FLENGTH % 2 )); then echo "FAIL length: $FNAME"; touch fail-subject-length; else echo "pass length: $FNAME"; fi'
This introduces a serious vulnerability: file names are not properly sanitized, and xargs -I{} injects them directly into the shell. For example, a malicious filename like:

" && echo RCE &&
would execute arbitrary commands, demonstrating an RCE vector.

Impact
Since this workflow runs with write-all GitHub permissions, an attacker exploiting this can:

Actions: write
Attestations: write
Checks: write
Contents: write
Deployments: write
Discussions: write
Issues: write
Packages: write
Pages: write
PullRequests: write
RepositoryProjects: write
SecurityEvents: write
Statuses: write

## Type of change

- [ ] Metadata related change
- [ ] Other

## Checklist:

- [ ] For metadata related changes, this PR code passes the GitHub Actions metadata validation


## Metadata PRs

Please note it may take up to 4 hours for merged changes to take effect on the metadata server.
