### PR TITLE
Add $CSBv1 token metadata for off chain registry

### DIFF
--- a/mappings/a6b92cdf28af39782e8baecb712298e0bc91787375569b1f0c8fd703244353427631.json
+++ b/mappings/a6b92cdf28af39782e8baecb712298e0bc91787375569b1f0c8fd703244353427631.json
@@ -1,0 +1,11 @@
+{
+  "subject": "a6b92cdf28af39782e8baecb712298e0bc91787375569b1f0c8fd703244353427631",
+  "name": "$CSBv1",
+  "ticker": "CSBv1",
+  "description": "Cardano Stake Bulls v1 WL Token. Unlock P2E levels & get CSBv2 airdrops. Join our Discord.",
+  "policy": "a6b92cdf28af39782e8baecb712298e0bc91787375569b1f0c8fd703",
+  "url": "https://stakebulls.arik-staking.tech",
+  "decimals": 4,
+  "logo": "ipfs://QmZrCdyup2sHdQFgMZW97KZqt13Ag7brWxCgDZ9aswzqeo",
+  "version": "1.0"
+}


### PR DESCRIPTION
This submission registers $CSBv1 (Cardano Stake Bulls) to enable proper display of token name, ticker, decimals, and logo in Cardano wallets and dApps. Total supply is 1B with 4 decimal precision.

# Pull Request Template

## Description

Please include a short summary of the changes in this PR.

## Type of change

- [x] Metadata related change
- [ ] Other

## Checklist:

- [ ] For metadata related changes, this PR code passes the GitHub Actions metadata validation


## Metadata PRs

Please note it may take up to 4 hours for merged changes to take effect on the metadata server.
