### PR TITLE
Add CI validation for subject field lowercase and filename match

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,7 +67,7 @@ jobs:
           cat "HEAD.diff"
           echo
 
-          rm -f fail-location fail-filename fail-subject-is-hex fail-subject-length || :
+          rm -f fail-location fail-filename fail-subject-is-hex fail-subject-length fail-subject-lowercase fail-subject-mismatch || :
           echo "Validating all changed PR files are in the ${LOCATION} directory and are hex and are valid length filenames:"
           echo
           awk '{print $2}' "HEAD.diff" | sort | while read -r fname; do
@@ -98,6 +98,27 @@ jobs:
               echo "FAIL length: $fname"
               touch fail-subject-length
             fi
+
+            # Check if the subject field inside the JSON is all lowercase hex
+            if [ -f "$fname" ]; then
+              subject=$(jq -r '.subject // empty' "$fname")
+              if [ -n "$subject" ]; then
+                if [[ "$subject" =~ ^[0-9a-f]+$ ]]; then
+                  echo "pass subject lowercase: $fname"
+                else
+                  echo "FAIL subject lowercase: $fname (subject: $subject)"
+                  touch fail-subject-lowercase
+                fi
+
+                # Check if filename matches the subject field
+                if [ "$justname" = "$subject" ]; then
+                  echo "pass subject matches filename: $fname"
+                else
+                  echo "FAIL subject matches filename: $fname (subject: $subject, filename: $justname)"
+                  touch fail-subject-mismatch
+                fi
+              fi
+            fi
           done
           echo
 
@@ -105,8 +126,10 @@ jobs:
           [ -f "fail-filename" ] && echo "ABORTING: File name validation failed"
           [ -f "fail-subject-is-hex" ] && echo "ABORTING: Subject-is-hex validation failed"
           [ -f "fail-subject-length" ] && echo "ABORTING: Subject-length validation failed"
+          [ -f "fail-subject-lowercase" ] && echo "ABORTING: Subject field must be all lowercase hex"
+          [ -f "fail-subject-mismatch" ] && echo "ABORTING: Subject field must match the filename"
           # [ -f "fail-location" ] || [ -f "fail-filename" ] || [ -f "fail-subject-is-hex" ] && exit 1
-          [ -f "fail-location" ] || [ -f "fail-filename" ] || [ -f "fail-subject-is-hex" ] || [ -f "fail-subject-length" ] && exit 1
+          [ -f "fail-location" ] || [ -f "fail-filename" ] || [ -f "fail-subject-is-hex" ] || [ -f "fail-subject-length" ] || [ -f "fail-subject-lowercase" ] || [ -f "fail-subject-mismatch" ] && exit 1
 
           popd
           echo "Obtaining the latest metadata GitHub PR validation tool:"


### PR DESCRIPTION
Enforce README rule #3 ("The file name must match the encoded subject key of the entry, all lowercase") at the CI level by adding two new checks to the PR validation pipeline:

1. Subject field inside the JSON must be all lowercase hex [0-9a-f]
2. Subject field must exactly match the filename (without .json)

Previously only the filename was validated for lowercase hex, but the subject field inside the JSON was never checked. This allowed entries with uppercase hex in the subject to pass CI. There are currently 40 existing files with uppercase hex that were merged before or while the filename check was being introduced (see #7933).

Also adds the new fail flags to the rm -f cleanup line to prevent stale flags from causing false failures.

Refs: #7933

# Pull Request Template

## Description

Please include a short summary of the changes in this PR.

## Type of change

- [ ] Metadata related change
- [ ] Other

## Checklist:

- [ ] For metadata related changes, this PR code passes the GitHub Actions metadata validation


## Metadata PRs

Please note it may take up to 4 hours for merged changes to take effect on the metadata server.
