### PR TITLE
ci: validate only mapping files, allow docs/other repo changes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -68,17 +68,19 @@ jobs:
           echo
 
           rm -f fail-location fail-filename fail-subject-is-hex fail-subject-length fail-subject-lowercase fail-subject-mismatch || :
-          echo "Validating all changed PR files are in the ${LOCATION} directory and are hex and are valid length filenames:"
+          echo "Validating all changed PR files in the ${LOCATION} directory are hex and are valid length filenames:"
           echo
           awk '{print $2}' "HEAD.diff" | sort | while read -r fname; do
             [ -z "$fname" ] && continue  # skip empty lines
 
-            # Check if filename starts with the correct location
+            # Only token mapping files are subject to metadata validation. Other
+            # files (e.g. README.md, LICENSE, .github/) are legitimate repository
+            # changes and are skipped here; they remain covered by human review.
             if [[ "$fname" =~ ^${LOCATION}/.*$ ]]; then
               echo "pass location: $fname"
             else
-              echo "FAIL location: $fname"
-              touch fail-location
+              echo "skip (non-mapping file): $fname"
+              continue
             fi
 
             # Check if filename is a hex string ending in .json
@@ -162,12 +164,12 @@ jobs:
           while read -r file; do
             echo "$VALIDATOR master/${file} pull-request/${file}"
             $VALIDATOR master/"${file}" pull-request/"${file}"
-          done < <(awk '/^M/ {print $2}' pull-request/HEAD.diff)
+          done < <(awk '/^M/ && $2 ~ /^mappings\// {print $2}' pull-request/HEAD.diff)
 
           while read -r file; do
             echo "$VALIDATOR pull-request/${file}"
             $VALIDATOR pull-request/"${file}"
-          done < <(awk '/^A/ {print $2}' pull-request/HEAD.diff)
+          done < <(awk '/^A/ && $2 ~ /^mappings\// {print $2}' pull-request/HEAD.diff)
           echo
 
       - name: Optional Check - LedgerX Top100


### PR DESCRIPTION
## Problem

The `Validate-Metadata` job asserts that **every** changed file in a PR is a hex-named JSON under `mappings/`. Any PR that touches a non-mapping file — docs, `LICENSE`, `.github/`, etc. — fails the gate even though no token mapping is involved.

This surfaced on the recently merged docs PR #7980 (README update), whose only change was `README.md`:

```
M	README.md
FAIL location: README.md      ← not under mappings/
FAIL is hex: README.md        ← filename isn't hex
FAIL length: README.md        ← odd-length name
```

That PR had to be merged manually past the red check. This PR makes the gate handle mixed/non-mapping PRs correctly.

## Change

- **Skip** non-mapping files in the validation loop (`skip (non-mapping file): <path>`) instead of failing them. They remain covered by the existing approval/human-review step.
- Restrict the downstream `token-metadata-creator validate` loops to `mappings/` files (`awk '/^M/ && $2 ~ /^mappings\//'` and the `/^A/` equivalent), so the validator no longer tries to run against non-mapping files.

Token **mapping submissions** are validated exactly as before — location, hex, length, subject-lowercase, and subject/filename match are all unchanged for files under `mappings/`.