### PR TITLE
Unblock fork PRs: opt in to fork checkout, bump actions/checkout to v5

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,20 +19,32 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Checkout both this pull request and the master branch
+      #
+      # GitHub runners refuse to check out fork pull request code from a
+      # `pull_request_target` workflow by default, because that context holds the
+      # base repository's GITHUB_TOKEN, secrets and cache scope. We opt in here
+      # because no step in this job ever *executes* checked-out pull request
+      # content: the files are read as data by jq and by token-metadata-creator,
+      # a binary downloaded from the offchain-metadata-tools release page.
+      #
+      # Do not add any step that runs code from pull-request/ -- a build, a
+      # dependency install, or a script kept in the repository -- without first
+      # removing this opt-in. Doing so would turn this job into a pwn request.
       - name: Checkout pull request
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           path: pull-request
+          allow-unsafe-pr-checkout: true
 
       - name: Checkout base branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           ref: master
           path: master
 
       - name: Checkout ledger na list
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           repository: 'LedgerHQ/app-cardano'
           ref: develop


### PR DESCRIPTION
GitHub runners now refuse to check out fork pull request code from a pull_request_target workflow, so Validate-Metadata fails at its first step on every fork pull request. Every open PR is currently red, including #8011 and #8012, before any metadata validation runs.

Opt in via allow-unsafe-pr-checkout on the pull request checkout step only. This is acceptable here because no step in the job executes checked-out content -- the files are read as data by jq and token-metadata-creator -- and the workflow already runs with a read-only token. A comment records that argument so it survives future edits.

actions/checkout is bumped v3 -> v5 on all three steps. v5.1.0 is the lowest release running node24, which also clears the Node 20 deprecation warning on this workflow.

 This is a deliberate quick fix to unblock the PR queue. It is the smallest change that gets validation running again. The better long-term shape — splitting the workflow by trust boundary so that fork code is only ever checked out in an untrusted pull_request context, with the secret-consuming Blockfrost check running separately with no checkout at all — is planned as a follow-up. 